### PR TITLE
Rollback to using our own supported mongo image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM mongo:3.2
+FROM quay.io/waffleio/official-mongo:3.4.2

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ takeout-mongo
 
 This is the Docker container for housing mongodb
 
-# TODO
-* Remove this repo, and the associated quay repo after all takeout customers have
-  upgrade to at least version 2.6.4 of waffle-takeout
+### Why?
+* Because sometimes the official mongo image ends up broke, preventing new
+  takeout signups from completing a successful installation
+* This is a buffer to ensure we always have a working version of mongo available
+  to our users
+
+### How
+* Browse to our [fork of the official mongo docker
+  image](https://github.com/waffleio/mongo)
+* Make the neccessary modifications to the specific version we desire
+* push that built image to `quay.io/waffleio/official-mongo:<TAG>`
+* modify the Dockerfile in THIS repo, update as necessary


### PR DESCRIPTION
* Due to recent events, the official docker image we rely on, does't
  work, preventing new installs from working right off the bat
* This gets us started with switching back to an image we know and will
  need to support in the future
* Adds instructions for publishing a new image
* The original build of THIS image continues to be automated through
  quay.io, however what we rely on is manual as it'll be use case
  dependant
* Modifies our FROM to indicate it'll be pulled from what we manually
  create and support
* connect waffleio/replicated#78